### PR TITLE
Updated project settings to also generate XML docs for dll interfaces

### DIFF
--- a/Src/IMX/Api/src/Imx.Sdk.Gen/Imx.Sdk.Gen.csproj
+++ b/Src/IMX/Api/src/Imx.Sdk.Gen/Imx.Sdk.Gen.csproj
@@ -21,6 +21,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/IMX/Imx.Sdk/Imx.Sdk.csproj
+++ b/Src/IMX/Imx.Sdk/Imx.Sdk.csproj
@@ -13,6 +13,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
# Summary

Dll assembly strips comments from interface, need to generate XML documents as well to be shipped along with dlls for the end user to be able to see the docs on the interfaces.